### PR TITLE
Add link to TUG 2017 to top level page

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,7 +25,7 @@ is now hosted on GitHub. This allows users and potential developers greater acce
 
 ## TUG 2017
 
-The 2017 Trilinos User Group Meeting (TUG) will be held in October in Albuquerque. 
+The [2017 Trilinos User Group Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2017.html) (TUG) will be held in October in Albuquerque. 
 
 ## Trilinos 12.10 Release
 


### PR DESCRIPTION
Add a link on the top level page to the TUG2017 page to make it a little easier to find instead of having to navigate through pull down menus.

@maherou 
@jwillenbring 