### PR TITLE
Add Trilinos Links to the home page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -45,11 +45,28 @@ Trilinos contains many packages, organized in [five product suites](product.html
 - Discretizations: Many finite element and similar approaches.
 - Framework: Tools for building, testing and integrating Trilinos capabilities.
 
-### Trilinos GitHub Location
-The [primary Trilinos repository](https://github.com/trilinos/Trilinos) is  hosted on GitHub.
+### Related sites for Trilinos information:
+[Trilinos Home Page](https://trilinos.github.io/)
+- Software description, downloads, doxygen, etc.
+- If you are a new user, this is a great place to start!  (See [also](https://github.com/trilinos/Trilinos#documentation).)
+
+[Trilinos Repository](https://github.com/trilinos/Trilinos)
+- Site for the Trilinos git repository to handle open/general issues.
+- Developer's wiki.
+
+[Trilinos Developers Site](https://github.com/trilinos/Trilinos/wiki)
+- Site for information that Trilinos developers need to know.
+
+[Sandia Trilinos Portal](https://snl-wiki.sandia.gov/display/TRIL/Trilinos+Portal)
+- Site containing Sandia specific information related to Trilinos.
+- Access limited to Sandia staff.
+
+[Sandia Trilinos Strategy Planning](https://sems-atlassian-srn.sandia.gov/projects/TRILINOS/summary)
+- Sandia Jira site for Trilinos strategy epics and tasks.
+- Access limited to Sandia staff.
 
 ### TUG 2020
-[The 2020 Trilinos User-Developer Group (TUG) Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2020.html) will be virtual.  Details available in August, 2020.
+[The 2020 Trilinos User-Developer Group (TUG) Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2020.html) was cancelled due to the COVID-19 pandemic.
 
 ### TUG 2019
 [The 2019 Trilinos User-Developer Group Meeting (TUG)](https://trilinos.github.io/trilinos_user-developer_group_meeting_2019.html) was held in October in Albuquerque.

--- a/pages/community/trilinos_user_meetings/trilinos_user-developer_group_meeting_2020.md
+++ b/pages/community/trilinos_user_meetings/trilinos_user-developer_group_meeting_2020.md
@@ -6,11 +6,11 @@ folder: community
 
 ## Dates
 
-- TBD
+- Cancelled
 
 ## Location
 
-- Virtual: Online
+- N/A
 - Contact: [Jim Willenbring](mailto:jmwille@sandia.gov)
 
 ## Trilinos Background
@@ -21,12 +21,12 @@ Full details of Trilinos and links to package websites can be found at the [Tril
 
 ## Meeting Overview
 
-TUG 2020 will be hosted online.  Meeting presentations will be recorded.  With sufficient interest, hands-on sessions will be considered.
+TUG 2020 was cancelled due to the COVID-19 pandemic.
 
 ## Registration
 
-TBD
+N/A
 
 ## Schedule
 
-TBD
+N/A


### PR DESCRIPTION
Added links to related Trilinos sites
 * [Trilinos Home Page](https://trilinos.github.io/)
 * [Trilinos Repository](https://github.com/trilinos/Trilinos)
 * [Trilinos Developers Site](https://github.com/trilinos/Trilinos/wiki)
 * [Sandia Trilinos Portal](https://snl-wiki.sandia.gov/display/TRIL/Trilinos+Portal)
 * [Sandia Trilinos Strategy Planning](https://sems-atlassian-srn.sandia.gov/projects/TRILINOS/summary)

These links are consistently displayed across these sites.

Additionally, updated the fact that the TUG 2020 was cancelled.