### PR TITLE
Move Header Information

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,13 @@
 <footer>
             <div class="row">
-                <div class="col-lg-12 footer">
+                <div class="col-md-6 footer">
+  <h3 style="color:blue;"><i>Trilinos is a community project.  
+  Please participate in our documentation effort.
+  If you see an error or want to contribute
+  content to this Trilinos website, fork the <a href="https://github.com/trilinos/trilinos.github.io" target="_blank">trilinos.github.io repository</a>, make your modifications and submit a pull request. Thank you.</i></h3>
+  <h4 style="color:black;">If you using Trilinos, please <a href="https://trilinos.github.io/cite.html" target="_blank">cite us.</a> For Trilinos logos, look <a href="https://github.com/trilinos/Logos" target="_blank">here</a>.</h4>
+                </div>
+                <div class="col-md-6 footer">
                &copy;{{ site.time | date: "%Y"  }} {{site.company_name}}. All rights reserved. <br />
 {% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
 <p><img src="{{ "images/trilinos.jpg" }}" alt="Trilinos"/></p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,10 +4,7 @@
 <p><img src="{{ "images/trilinos.jpg" }}" alt="Trilinos"/></p>
                 </div>
                 <div class="col-md-6 header">
-<h3 style="color:blue;"><i>Trilinos is a community project.  Please participate in our documentation effort.
-  If you see an error or want to contribute
-  content to help other users, fork the <a href="https://github.com/trilinos/trilinos.github.io" target="_blank">trilinos.github.io repository</a>, make your modifications and submit a pull request. Thank you.</i></h3>
-  <h4 style="color:black;">If using Trilinos, please <a href="https://trilinos.github.io/cite.html" target="_blank">cite us.</a> For Trilinos logos, look <a href="https://github.com/trilinos/Logos" target="_blank">here.</a> Thank you.</h4>
+<h3 style="color:blue;"><i>The main Trilinos git repository is on GitHub at <a href="https://github.com/trilinos/Trilinos" target="_blank">https://github.com/trilinos/Trilinos</a>, where one can open issues and provide contributions.  Additional details for developers can be found at the <a href="https://github.com/trilinos/Trilinos/wiki" target="_blank">Trilinos Developers Site</a>.
                 </div>
             </div>
 </header>


### PR DESCRIPTION
The header information included language that suggested
to contribute to Trilinos use the trilinos.github.io.
Thus we got a question that should have gone to
https://github.com/trilinos/Trilinos.

Cleaned up the language and moved it to the footer.
Added text to header about where to go to contribute to
Trilinos.