### PR TITLE
Adapt to syntax change to run jekyll site warning free

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ description: "The Trilinos Project Wiki"
 # needed for sitemap.xml file only
 url: https://trilinos.github.io
 
-gems:
+plugins:
   - jekyll-redirect-from
 
 google_analytics: true


### PR DESCRIPTION
This adapts the `_config.yml` file to avoid the following warning: 

```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```
when running `bundle exec jekyll serve`.

