### PR TITLE
Add EuroTUG 2022 to list of events

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -111,6 +111,10 @@ topnav_dropdowns:
       url: /events.html
       output: web
       submenus:
+        - title: European Trilinos User Group Meeting 2022
+          url: /european_trilinos_user_group_meeting_2022.html
+          output: web
+
         - title: Trilinos User-Developer Group Meeting 2019
           url: /trilinos_user-developer_group_meeting_2019.html
           output: web

--- a/index.md
+++ b/index.md
@@ -73,3 +73,6 @@ Trilinos contains many packages, organized in [five product suites](product.html
 - [The 2021 Trilinos User-Developer Group (TUG) Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2021.html) will be virtually held November 30 - December 2, 2021.
 - [The 2020 Trilinos User-Developer Group (TUG) Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2020.html) was cancelled due to the COVID-19 pandemic.
 - [The 2019 Trilinos User-Developer Group (TUG) Meeting](https://trilinos.github.io/trilinos_user-developer_group_meeting_2019.html) was held in October in Albuquerque.
+
+### European Trilinos User Group (EuroTUG) Meetings
+- [The 2022 European Trilinos User Group (EuroTUG) Meeting](european_trilinos_user_group_meeting_2022.html) will be held September 12 - 14, 2022.

--- a/pages/community/european_trilinos_user_meetings/european_trilinos_user_group_meeting_2022.md
+++ b/pages/community/european_trilinos_user_meetings/european_trilinos_user_group_meeting_2022.md
@@ -1,0 +1,19 @@
+---
+title: European Trilinos User Group Meeting 2022
+permalink: european_trilinos_user_group_meeting_2022.html
+folder: community
+---
+
+**European Trilinos User Group Meeting 2022**  
+**Sep 12-14, 2022**  
+**Location:**
+- Munich: Germany
+
+Co-sponsored by
+- research center [dtec.bw](https://dtecbw.de/), in particular its project [hpw.bw: competence platform for software efficiency and supercomputing](https://dtecbw.de/home/forschung/hsu/projekt-hpcbw/projekt-hpcbw)
+- the [Leibniz-Rechenzentrum](https://www.lrz.de)
+
+The Trilinos Project team will be holding a two-day European Trilinos User Group meeting on Sep 13-14, 2022 in Munich, Germany. Prior to the EuroTUG workshop, a one-day introductory course to Trilinos will be offered on Sep 12, 2022.
+
+For all details and updates on the exaxt venue, scientific programm, and registration, please consult the [EuroTUG 2022 website](https://eurotug.github.io).
+

--- a/pages/community/events.md
+++ b/pages/community/events.md
@@ -4,6 +4,7 @@ permalink: events.html
 folder: community
 ---
 
+*   [European Trilinos User Group 2022](european_trilinos_user_group_meeting_2022.html) -- Sep 12-14, 2022, Munich, Germany
 *   [European Trilinos User Group 2019](european_trilinos_user_group_meeting_2019.html) -- Jun 11, 2019, Zürich, Switzerland
 *   [US Trilinos User Group 2016](trilinos_user-developer_group_meeting_2016.html) -- Oct 24-26, 2016, Albuquerque, NM, USA
 *   [European Trilinos User Group 2016](european_trilinos_user_group_meeting_2016.html) -- Apr 18-20, 2016, Garching, Germany


### PR DESCRIPTION
Add some basic info on the EuroTUG 2022 to be held in September 2022 in Munich.