### PR TITLE
Add Adelus to direct solvers on linear solvers page

### DIFF
--- a/pages/products/linear.md
+++ b/pages/products/linear.md
@@ -140,6 +140,16 @@ Y
 
 <tr>
 
+<td valign="top" width="99"><a href="#adelus-direct-dense-linear-solver">Adelus</a></td>
+
+<td width="68"></td>
+
+<td width="68"></td>
+
+</tr>
+
+<tr>
+
 <td rowspan="2" width="261">Incomplete factorizations, SOR methods, Additive Schwarz</td>
 
 <td valign="top" width="99"><a href="#ifpack-point-preconditioning-incomplete-factorizations-and-classical-domain-decomposition">Ifpack</a></td>

--- a/pages/products/linear.md
+++ b/pages/products/linear.md
@@ -378,6 +378,19 @@ Point-of-contact: Siva Rajamanickam (srajama@sandia.gov)
 Amesos2 can be considered a templated version of Amesos that supports a wider variety of scalar and index types. Amesos2 provides two internal serial direct solvers, KLU2 (as of release 11.12) and Basker (as of release 11.14). Users of prior releases will need a third-party direct solver, such as SuperLU.
 
 
+### **Adelus**: direct dense linear solver
+
+Point-of-contact: Vinh Dang (vqdang@sandia.gov)
+[https://trilinos.github.io/adelus.html](adelus.html)
+
+
+Adelus performs LU factorization with partial pivoting and solves for a dense (real or complex) linear equation system on a distributed computing system using MPI for message passing. It can be considered a replacement for Pliris, which runs only on CPUs. Adelus uses Kokkos and Kokkos Kernels to achieve performance portability on heterogeneous architectures equipped with CPUs and accelerated hardware such as GPUs.
+
+The matrix is blocked mapped onto MPI processes (either on host memory or device memory). It is factored and solved as if it was torus-wrapped for an optimal balance of computation and communication. A permutation operation is performed on the results to restore the results to their correct position so the torus-wrap distribution is hidden to the user. Each process contains blocks of the matrix and the right hand sides. A distribution function is used to optimally load balance the computation and communication during the LU factorization of the matrix. Each process handles its own workload through the Kokkos Kernels BLAS routines optimized for multi-threaded CPUs and massively parallel GPUs. GPU-aware MPI can be used on GPU architectures to allows direct communication among GPU buffers.
+
+Adelus provides three interfaces, FactorSolve (factors and solves a dense system in which matrix and RHS are packed in Kokkos View), Factor (factors a dense matrix for later solve), and Solve (solves a previously factored dense matrix for provided RHS). Adelus supports solving for multiple RHS vectors. Adelus allows applications to concurrently launch multiple solvers each of which is associated with a MPI sub-communicator of the MPI_COMM_WORLD.
+
+
 * * *
 
 </details>


### PR DESCRIPTION
Adding a summary of Adelus to direct solvers section on the linear solvers page. A page for Adelus will be added later.