### PR TITLE
Move Citation Info; Update Capabilities Description

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -72,29 +72,9 @@ Trilinos was awarded one of two HPC Software Challenge Awards at SC2004 for its 
 
 ## Citing Trilinos
 
-If you are using Trilinos, please cite our software in your publications. Below is a suitable BibTeX entry:
 
-```bibtex
-@Manual{trilinos,
-  title        = {The {T}rilinos {P}roject},
-  author       = {The Trilinos Project Team},
-  organization = {Linux Foundation / High Performance Software Foundation},
-  year         = {2026},
-  url          = {https://trilinos.github.io},
-  note         = {Accessed: January 8, 2026},
-}
-```
-
-For specific packages, you may cite their individual webpages. For example:
-```
-@Manual{muelu,
-  title  = {The {M}uelu {P}roject},
-  author = {The {M}uelu {T}eam}},
-  year   = {2026},
-  url    = {https://trilinos.github.io/docs/muelu/index.html}
-  note   = {Accessed: January 8, 2026},
-}
-```
+See [Citing Trilinos](documentation.html#citing-trilinos) on the
+[Documentation page](documentation.html).
 
 ---
 

--- a/pages/capabilities.md
+++ b/pages/capabilities.md
@@ -53,7 +53,7 @@ Trilinos is a comprehensive software framework for scientific computing, providi
 
 ---
 
-## Discretization Utilities
+## Discretization Tools
 
 - <strong>Finite Element Local Assembly</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/intrepid2#readme">Intrepid2</a> </em></span><br />
   Tools for local assembly of finite element matrices and vectors, supporting high-order compatible discretizations for function spaces such as H(grad), H(curl), H(div), and L<sup>2</sup>. Capabilities include geometric operations, basis functions, orientation tools, and projection methods for efficient finite element computations.
@@ -66,6 +66,9 @@ Trilinos is a comprehensive software framework for scientific computing, providi
 
 - <strong>Meshless Approximation of Linear Operators</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/compadre#readme">Compadre</a> </em></span><br />
   Tools for meshless approximation of linear operators using generalized moving least squares (GMLS). These capabilities support applications such as data transfer and meshless discretization of PDEs, leveraging hierarchical parallelism for performance portability.
+
+- <strong>Cell Topology</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/shards#readme">Shards</a> </em></span><br />
+  Tools for defining and querying cell topology, including support for triangles, quadrilaterals, tetrahedrons, hexahedrons, wedges, and pyramids. These capabilities are essential for finite element and finite volume discretizations.
 
 ---
 
@@ -117,9 +120,6 @@ Trilinos is a comprehensive software framework for scientific computing, providi
 - <strong>Mesh I/O</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/sandialabs/seacas">SEACAS</a> , <a href="https://github.com/trilinos/Trilinos/tree/master/packages/stk#readme">STK</a> </em></span><br />
   Support for reading and writing mesh data in various formats, including Exodus, NetCDF, and other widely used formats in scientific computing. These capabilities enable interoperability with external mesh generation and visualization tools. Integration with visualization tools for inspecting and analyzing mesh structures and simulation results. These capabilities include support for exporting data to visualization software such as ParaView and VisIt.
 
-- <strong>Cell Topology</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/shards#readme">Shards</a> </em></span><br />
-  Tools for defining and querying cell topology, including support for triangles, quadrilaterals, tetrahedrons, hexahedrons, wedges, and pyramids. These capabilities are essential for finite element and finite volume discretizations.
-
 - <strong>Level-Set Methods</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/krino#readme">Krino</a> </em></span><br />
   Capabilities for handling level-set representations of geometries, enabling simulations involving moving boundaries, interfaces, and topological changes. These methods are particularly useful for fluid-structure interaction and multiphase flow problems.
 
@@ -159,8 +159,8 @@ Trilinos is a comprehensive software framework for scientific computing, providi
 - <strong>Utility and Helper Tools</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/teuchos#readme">Teuchos</a> </em></span><br />
   Collection of tools for memory management, parameter lists, templated wrappers for BLAS/LAPACK, and XML parsing. These utilities simplify programming tasks and ensure consistent coding practices.
 
-- <strong>Matrix-Free Linear Algebra</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/galeri#readme">Galeri</a> </em></span><br />
-  Tools for generating test problems and matrix-free linear algebra objects, including structured grids and finite difference operators. Galeri provides a lightweight and flexible framework for prototyping and testing numerical algorithms.
+- <strong>Test Matrix Generation</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/galeri#readme">Galeri</a> </em></span><br />
+Galeri is a Trilinos package that generates standard test problems and corresponding sparse matrices (and often coordinates and right-hand sides) for linear system and preconditioner/solver benchmarking. It provides parameter-driven constructors for common structured-grid PDE discretizations (e.g., Poisson and convection–diffusion) and simple graph/matrix models, primarily to support rapid prototyping and verification.
 
 - <strong>Tensor Algebra Utilities</strong> <span style="float:right;"><em>Provided by: <a href="https://github.com/trilinos/Trilinos/tree/master/packages/minitensor#readme">MiniTensor</a> </em></span><br />
   Compact library for tensor algebra, supporting operations on small tensors, vectors, and matrices. MiniTensor is optimized for performance and portability, making it suitable for applications in mechanics and material modeling.

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -41,6 +41,44 @@ Find out more about Trilinos: how to use it, install it, configure it, and even 
 
 ---
 
+## Citing Trilinos
+
+If you are using Trilinos, please cite us in your publications:
+
+**Mayr, M., et al. (2026). Trilinos: Enabling Scientific Computing Across Diverse Hardware Architectures at Scale. ACM Transactions on Mathematical Software. https://doi.org/10.1145/3802822**
+
+```bibtex
+@article{10.1145/3802822,
+  author    = {Mayr, Matthias and Heinlein, Alexander and Glusa, Christian and Rajamanickam, Sivasankaran and Arnst, Maarten and Bartlett, Roscoe A. and Berger-Vergiat, Luc and Boman, Erik G. and Devine, Karen and Harper, Graham and Heroux, Michael and Hoemmen, Mark and Hu, Jonathan and Kelley, Brian and Kim, Kyungjoo and Kouri, Drew P. and Kuberry, Paul and Liegeois, Kim and Ober, Curtis C. and Pawlowski, Roger and Pearson, Carl and Perego, Mauro and Phipps, Eric and Ridzal, Denis and Roberts, Nathan V. and Siefert, Christopher M. and Thornquist, Heidi K. and Tomasetti, Romin and Trott, Christian R. and Tuminaro, Raymond S. and Willenbring, James M. and Wolf, Michael M. and Yamazaki, Ichitaro},
+  title     = {Trilinos: Enabling Scientific Computing Across Diverse Hardware Architectures at Scale},
+  year      = {2026},
+  publisher = {Association for Computing Machinery},
+  address   = {New York, NY, USA},
+  issn      = {0098-3500},
+  url       = {https://doi.org/10.1145/3802822},
+  doi       = {10.1145/3802822},
+  abstract  = {Trilinos is a community-developed, open-source software framework that facilitates building large-scale, complex, multiscale, multiphysics simulation code bases for scientific and engineering problems. Since the Trilinos framework has undergone substantial changes to support new applications and new hardware architectures, this document is an update to “An Overview of the Trilinos project” by Heroux et al. (ACM Transactions on Mathematical Software, 31(3):397–423, 2005). It describes the design of Trilinos, introduces its new organization in product areas, and highlights established and new features available in Trilinos. Particular focus is put on the modernized software stack based on the Kokkos ecosystem to deliver performance portability across heterogeneous hardware architectures. This paper also outlines the organization of the Trilinos community and the contribution model to help onboard interested users and contributors.},
+  journal   = {ACM Transactions on Mathematical Software},
+  month     = March,
+  keywords  = {Heterogeneous Hardware Architectures, High-Performance Computing, Performance Portability, Scientific Software Frameworks}
+  }
+```
+
+Below is a BibTeX entry for the Trilinos GitHub repository:
+
+```bibtex
+@Manual{trilinos,
+  title        = {The {T}rilinos {P}roject},
+  author       = {The Trilinos Project Team},
+  organization = {Linux Foundation / High Performance Software Foundation},
+  year         = {2026},
+  url          = {https://trilinos.github.io},
+  note         = {Accessed: January 8, 2026},
+}
+```
+
+---
+
 ## Tutorials and Videos
 
 - [Trilinos Hands-on Tutorial](https://github.com/trilinos/Trilinos_tutorial/wiki/TrilinosHandsOnTutorial)


### PR DESCRIPTION
* Replace About page BibTeX block with link to “Citing Trilinos” section on Documentation page
* Add “Citing Trilinos” section to Documentation with 2026 TOMS paper + BibTeX and GitHub repo BibTeX
* Rename “Discretization Utilities” to “Discretization Tools”
* Relocate Shards “Cell Topology” entry to the discretization section
* Rename/refresh Galeri entry from “Matrix-Free Linear Algebra” to “Test Matrix Generation” with updated description