### PR TITLE
Add gtest to runner environment

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -37,7 +37,7 @@ jobs:
       if: always()
       run: |
         sudo apt-get update
-        sudo apt-get install -yq doxygen graphviz texlive texlive-latex-extra ghostscript cmake mpi-default-bin mpi-default-dev libopenblas-serial-dev ccache
+        sudo apt-get install -yq doxygen graphviz texlive texlive-latex-extra ghostscript cmake mpi-default-bin mpi-default-dev libopenblas-serial-dev libgtest-dev ccache
     
     - name: Check out webpage repo
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
This gets us past the CMake error:
https://github.com/cgcgcg/trilinos.github.io/actions/runs/24347582961/job/71092639267