### PR TITLE
Add build of build reference

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -37,7 +37,7 @@ jobs:
       if: always()
       run: |
         sudo apt-get update
-        sudo apt-get install -yq doxygen graphviz texlive texlive-latex-extra ghostscript cmake mpi-default-bin mpi-default-dev libopenblas-serial-dev libgtest-dev ccache
+        sudo apt-get install -yq doxygen graphviz texlive texlive-latex-extra ghostscript cmake mpi-default-bin mpi-default-dev libopenblas-serial-dev libgtest-dev ccache python3-docutils
     
     - name: Check out webpage repo
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -141,6 +141,13 @@ jobs:
           fi
         done   
         popd
+
+    - name: Generate build reference
+      run: |
+        cd ${{ env.TRILINOS_SOURCE }}/doc/build_ref/
+        make
+        cp TrilinosBuildReference.pdf  $GITHUB_WORKSPACE/${{ env.WEBPAGES_DIR }}/pdfs/
+        cp TrilinosBuildReference.html $GITHUB_WORKSPACE/${{ env.WEBPAGES_DIR }}/
 
     - name: Create PR
       uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -27,9 +27,8 @@ Find out more about Trilinos: how to use it, install it, configure it, and even 
 
 - [Quick Configure, Build, and Install Hints](https://github.com/trilinos/Trilinos/blob/master/INSTALL.rst)
     - Basic instructions for setting up Trilinos.
-- [Trilinos Configure, Build, Test, and Install Reference Guide](pdfs/TrilinosBuildReference.pdf)
+- Trilinos Configure, Build, Test, and Install Reference Guide [html](TrilinosBuildReference.html), [pdf](pdfs/TrilinosBuildReference.pdf) 
     - Instructions for building Trilinos 10.0 and later.
-    - [Partial version](https://github.com/trilinos/Trilinos/blob/master/doc/build_ref/TrilinosBuildReferenceTemplate.rst)
 - [Simple Example of Building Against Installed Trilinos with CMake](https://github.com/trilinos/Trilinos/tree/master/demos/simpleBuildAgainstTrilinos)
     - A functional example for applications using `find_package(Trilinos)`.
 - [TriBITS Users Guide and Reference](https://tribitspub.github.io/TriBITS/users_guide/index.html)


### PR DESCRIPTION
Builds the build reference documentation from doc/build_ref

See: https://cgcgcg.github.io/trilinos.github.io/documentation.html